### PR TITLE
寻找更简便的非gradio界面实现方式

### DIFF
--- a/nicegui_example.py
+++ b/nicegui_example.py
@@ -123,6 +123,9 @@ def create_main_interface():
             # 结果显示区域
             result_area = ui.textarea('结果将在这里显示...').classes('w-full').style('min-height: 200px')
 
-if __name__ == '__main__':
-    create_main_interface()
+# 直接调用，不需要 main guard
+create_main_interface()
+
+# 启动服务器
+if __name__ in {"__main__", "__mp_main__"}:
     ui.run(port=8080, title='同义词替换工具')

--- a/nicegui_example.py
+++ b/nicegui_example.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+使用NiceGUI实现同义词替换界面
+优点：界面更现代化，组件更丰富
+"""
+
+from nicegui import ui, run
+import pandas as pd
+
+# 全局状态
+state = {
+    'input_text': '',
+    'competitor_data': [],
+    'uih_data': [],
+    'final_result': ''
+}
+
+def create_main_interface():
+    """创建主界面"""
+    
+    # 页面标题
+    ui.label('同义词替换').classes('text-3xl font-bold text-center mb-8')
+    
+    # 使用卡片布局，更现代化
+    with ui.card().classes('w-full max-w-6xl mx-auto'):
+        
+        # Step 1: 输入文本
+        with ui.expansion('Step 1: 输入文本', icon='edit').classes('w-full'):
+            ui.label('请在下方文本框中输入需要测试的文本内容').classes('text-gray-600 mb-2')
+            
+            text_area = ui.textarea(
+                placeholder='在这里输入你的文本...'
+            ).classes('w-full').style('min-height: 150px')
+            
+            def process_step1():
+                state['input_text'] = text_area.value
+                ui.notify('Step 1 处理完成！', type='positive')
+                # 这里添加你的处理逻辑
+                
+            ui.button(
+                '开始处理 (Step1获取初步距离答案/友商以及UIH技术名)', 
+                on_click=process_step1
+            ).classes('mt-4 bg-blue-500 text-white px-6 py-2 rounded')
+
+        # Step 2: 更新待定信息
+        with ui.expansion('Step 2: 更新待定信息', icon='table_chart').classes('w-full mt-4'):
+            
+            with ui.row().classes('w-full gap-4'):
+                # 友商技术信息表
+                with ui.column().classes('flex-1'):
+                    ui.label('友商技术信息表').classes('text-lg font-semibold mb-2')
+                    
+                    # 创建可编辑表格
+                    competitor_columns = [
+                        {'name': 'idx', 'label': 'ID', 'field': 'idx', 'sortable': True},
+                        {'name': 'competitor_name', 'label': '竞争对手名称', 'field': 'competitor_name'},
+                        {'name': 'competitor_product', 'label': '竞争对手产品', 'field': 'competitor_product'},
+                        {'name': 'uih_product', 'label': 'UIH产品', 'field': 'uih_product'},
+                        {'name': 'belong_to_uih', 'label': '是否拒答', 'field': 'belong_to_uih'},
+                        {'name': 'candidate_product', 'label': '候选产品', 'field': 'candidate_product'},
+                    ]
+                    
+                    competitor_rows = [
+                        {
+                            'idx': 0,
+                            'competitor_name': '西门子',
+                            'competitor_product': 'DTI',
+                            'uih_product': 'DTI',
+                            'belong_to_uih': False,
+                            'candidate_product': 'GE, 飞利浦'
+                        }
+                    ]
+                    
+                    competitor_table = ui.table(
+                        columns=competitor_columns,
+                        rows=competitor_rows,
+                        row_key='idx'
+                    ).classes('w-full')
+                
+                # UIH技术信息表  
+                with ui.column().classes('flex-1'):
+                    ui.label('UIH技术信息表').classes('text-lg font-semibold mb-2')
+                    
+                    uih_columns = [
+                        {'name': 'idx', 'label': 'ID', 'field': 'idx'},
+                        {'name': 'belong_to_which', 'label': '属于哪个', 'field': 'belong_to_which'},
+                        {'name': 'corresponding_product', 'label': '对应产品', 'field': 'corresponding_product'},
+                        {'name': 'uih_product', 'label': 'UIH产品', 'field': 'uih_product'},
+                        {'name': 'candidate_product', 'label': '候选产品', 'field': 'candidate_product'},
+                    ]
+                    
+                    uih_rows = [
+                        {
+                            'idx': 0,
+                            'belong_to_which': 'DTI',
+                            'corresponding_product': 'DTI',
+                            'uih_product': ['UIH', 'DTI'],
+                            'candidate_product': ['GE']
+                        }
+                    ]
+                    
+                    uih_table = ui.table(
+                        columns=uih_columns,
+                        rows=uih_rows,
+                        row_key='idx'
+                    ).classes('w-full')
+
+        # Step 3: 获取最终结果
+        with ui.expansion('Step 3: 获取最终拒答策略', icon='psychology').classes('w-full mt-4'):
+            ui.label('基于前两步的选择，生成最终的拒答策略结果').classes('text-gray-600 mb-4')
+            
+            def process_final():
+                ui.notify('正在生成拒答策略...', type='info')
+                # 这里添加最终处理逻辑
+                state['final_result'] = "拒答策略已生成"
+                result_area.set_text(state['final_result'])
+                
+            ui.button(
+                '开始处理 (Step3获取最终拒答策略)', 
+                on_click=process_final
+            ).classes('bg-green-500 text-white px-6 py-2 rounded mb-4')
+            
+            # 结果显示区域
+            result_area = ui.textarea('结果将在这里显示...').classes('w-full').style('min-height: 200px')
+
+if __name__ == '__main__':
+    create_main_interface()
+    ui.run(port=8080, title='同义词替换工具')

--- a/simple_nicegui.py
+++ b/simple_nicegui.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+简化版NiceGUI实现 - 避免常见陷阱
+"""
+
+from nicegui import ui
+import pandas as pd
+
+# 页面标题
+ui.label('同义词替换').style('font-size: 2em; font-weight: bold; text-align: center')
+
+# Step 1
+with ui.card().style('width: 100%; margin: 20px 0'):
+    ui.label('Step 1: 输入文本').style('font-size: 1.5em; font-weight: bold')
+    ui.label('请在下方文本框中输入需要测试的文本内容').style('color: gray')
+    
+    text_input = ui.textarea(placeholder='西门子的DTI怎么样').style('width: 100%; height: 150px')
+    
+    def process_step1():
+        if text_input.value:
+            ui.notify('Step 1 处理完成！', color='positive')
+        else:
+            ui.notify('请先输入文本', color='negative')
+    
+    ui.button('开始处理 (Step1)', on_click=process_step1).style('background: #4CAF50; color: white; padding: 10px 20px')
+
+# Step 2
+with ui.card().style('width: 100%; margin: 20px 0'):
+    ui.label('Step 2: 更新待定信息').style('font-size: 1.5em; font-weight: bold')
+    
+    with ui.row().style('width: 100%'):
+        with ui.column().style('width: 48%'):
+            ui.label('友商技术信息表').style('font-weight: bold')
+            
+            # 简单的表格显示
+            competitor_data = [
+                ['0', '西门子', 'DTI', 'DTI', 'false', 'GE, 飞利浦']
+            ]
+            
+            with ui.grid(columns=6).style('width: 100%'):
+                # 表头
+                ui.label('idx').style('font-weight: bold')
+                ui.label('竞争对手').style('font-weight: bold')
+                ui.label('竞争产品').style('font-weight: bold')
+                ui.label('UIH产品').style('font-weight: bold')
+                ui.label('是否拒答').style('font-weight: bold')
+                ui.label('候选产品').style('font-weight: bold')
+                
+                # 数据行
+                for row in competitor_data:
+                    for cell in row:
+                        ui.input(value=cell).style('width: 100%')
+        
+        with ui.column().style('width: 48%; margin-left: 4%'):
+            ui.label('UIH技术信息表').style('font-weight: bold')
+            
+            uih_data = [
+                ['0', 'DTI', 'DTI', '["UIH", "DTI"]', '["GE"]']
+            ]
+            
+            with ui.grid(columns=5).style('width: 100%'):
+                # 表头
+                ui.label('idx').style('font-weight: bold')
+                ui.label('属于哪个').style('font-weight: bold')
+                ui.label('对应产品').style('font-weight: bold')
+                ui.label('UIH产品').style('font-weight: bold')
+                ui.label('候选产品').style('font-weight: bold')
+                
+                # 数据行
+                for row in uih_data:
+                    for cell in row:
+                        ui.input(value=cell).style('width: 100%')
+
+# Step 3
+with ui.card().style('width: 100%; margin: 20px 0'):
+    ui.label('Step 3: 获取最终拒答策略').style('font-size: 1.5em; font-weight: bold')
+    ui.label('基于前两步的选择，生成最终的拒答策略结果').style('color: gray')
+    
+    def process_final():
+        ui.notify('拒答策略生成完成！', color='positive')
+        result_text.set_text('拒答策略：您好，您的提问涉及西门子的DTI技术，很抱歉无法为您提供咨询服务...')
+    
+    ui.button('开始处理 (Step3获取最终拒答策略)', on_click=process_final).style('background: #2196F3; color: white; padding: 10px 20px')
+    
+    result_text = ui.textarea(placeholder='结果将在这里显示...').style('width: 100%; height: 200px; margin-top: 10px')
+
+# 启动应用
+ui.run(port=8080, title='同义词替换工具')

--- a/simple_streamlit.py
+++ b/simple_streamlit.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+超简单的Streamlit实现 - 零学习成本
+"""
+
+import streamlit as st
+import pandas as pd
+
+# 页面配置
+st.set_page_config(page_title="同义词替换", page_icon="🔄", layout="wide")
+
+st.title("🔄 同义词替换")
+
+# Step 1: 输入文本
+st.header("Step 1: 输入文本")
+st.write("请在下方文本框中输入需要测试的文本内容")
+
+input_text = st.text_area("输入文本", height=150, placeholder="西门子的DTI怎么样")
+
+if st.button("🚀 开始处理 (Step1)", type="primary"):
+    if input_text:
+        st.success("✅ Step 1 处理完成！")
+        st.session_state['text_processed'] = True
+    else:
+        st.error("请先输入文本")
+
+# Step 2: 更新待定信息
+st.header("Step 2: 更新待定信息")
+
+col1, col2 = st.columns(2)
+
+with col1:
+    st.subheader("👥 友商技术信息表")
+    
+    # 初始化数据
+    if 'competitor_data' not in st.session_state:
+        st.session_state.competitor_data = pd.DataFrame({
+            'idx': [0],
+            'competitor_name': ['西门子'],
+            'competitor_product': ['DTI'],
+            'uih_product': ['DTI'],
+            'belong_to_uih': [False],
+            'candidate_product': ['GE, 飞利浦']
+        })
+    
+    # 可编辑表格 - Streamlit的data_editor非常强大且易用
+    st.session_state.competitor_data = st.data_editor(
+        st.session_state.competitor_data,
+        num_rows="dynamic",  # 允许添加/删除行
+        use_container_width=True
+    )
+
+with col2:
+    st.subheader("🏢 UIH技术信息表")
+    
+    if 'uih_data' not in st.session_state:
+        st.session_state.uih_data = pd.DataFrame({
+            'idx': [0],
+            'belong_to_which': ['DTI'],
+            'corresponding_product': ['DTI'],
+            'uih_product': ['UIH, DTI'],
+            'candidate_product': ['GE']
+        })
+    
+    st.session_state.uih_data = st.data_editor(
+        st.session_state.uih_data,
+        num_rows="dynamic",
+        use_container_width=True
+    )
+
+# Step 3: 获取最终结果
+st.header("Step 3: 获取最终拒答策略")
+st.write("基于前两步的选择，生成最终的拒答策略结果")
+
+if st.button("🎯 开始处理 (Step3)", type="primary"):
+    with st.spinner("正在生成拒答策略..."):
+        # 模拟处理时间
+        import time
+        time.sleep(1)
+        
+        st.success("✅ 拒答策略生成完成！")
+        
+        # 显示结果表格
+        result_data = pd.DataFrame({
+            'refuse_index': [3],
+            'candidate_text': ['西门子的DTI怎么样'],
+            'is_refuse': [True],
+            'refuse_reason': [False],
+            'refuse_tech': ['您好，您的提问涉及西门子的DTI技术，很抱歉无法为您提供咨询服务...']
+        })
+        
+        st.subheader("📋 拒答结果")
+        st.dataframe(result_data, use_container_width=True)
+
+# 侧边栏
+with st.sidebar:
+    st.header("ℹ️ 使用说明")
+    st.markdown("""
+    ### 操作步骤：
+    1. **输入文本** - 在文本框中输入要测试的内容
+    2. **编辑表格** - 双击表格单元格进行编辑
+    3. **生成策略** - 点击按钮获取拒答策略
+    
+    ### 表格操作：
+    - 双击单元格编辑
+    - 点击 + 添加新行
+    - 选中行后按Delete删除
+    """)
+    
+    if 'text_processed' in st.session_state:
+        st.success("Step 1 已完成 ✅")
+    else:
+        st.info("等待输入文本 ⏳")

--- a/simple_web_app.py
+++ b/simple_web_app.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+最简单的Web界面实现 - 只需要Python标准库
+无需安装任何额外依赖！
+"""
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import urllib.parse
+import json
+import webbrowser
+import threading
+
+# HTML模板
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>同义词替换</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; }
+        .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+        .card { background: white; border-radius: 8px; padding: 20px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .title { font-size: 2em; font-weight: bold; text-align: center; color: #333; margin-bottom: 30px; }
+        .step-title { font-size: 1.5em; font-weight: bold; color: #444; margin-bottom: 15px; }
+        .step-desc { color: #666; margin-bottom: 15px; }
+        textarea { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px; }
+        button { background: #007bff; color: white; border: none; padding: 12px 24px; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        button:hover { background: #0056b3; }
+        button.success { background: #28a745; }
+        button.success:hover { background: #1e7e34; }
+        .table-container { display: flex; gap: 20px; margin: 20px 0; }
+        .table-half { flex: 1; }
+        table { width: 100%; border-collapse: collapse; margin: 10px 0; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background: #f8f9fa; font-weight: bold; }
+        input[type="text"] { width: 100%; padding: 4px; border: none; background: transparent; }
+        .result-area { background: #f8f9fa; padding: 15px; border-radius: 4px; margin-top: 15px; }
+        .tabs { display: flex; margin-bottom: 20px; border-bottom: 1px solid #ddd; }
+        .tab { padding: 12px 24px; cursor: pointer; border-bottom: 2px solid transparent; }
+        .tab.active { border-bottom-color: #007bff; color: #007bff; font-weight: bold; }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1 class="title">同义词替换</h1>
+        
+        <div class="tabs">
+            <div class="tab active" onclick="showTab('tab1')">📝 文本处理</div>
+            <div class="tab" onclick="showTab('tab2')">🔧 拒答设定</div>
+            <div class="tab" onclick="showTab('tab3')">📚 原文库结论查库</div>
+        </div>
+
+        <!-- Tab 1: 文本处理 -->
+        <div id="tab1" class="tab-content active">
+            <div class="card">
+                <h2 class="step-title">Step 1: 输入文本</h2>
+                <p class="step-desc">请在下方文本框中输入需要测试的文本内容</p>
+                
+                <textarea id="inputText" rows="6" placeholder="西门子的DTI怎么样"></textarea>
+                
+                <button onclick="processStep1()" style="margin-top: 15px;">
+                    🚀 开始处理 (Step1获取初步距离答案/友商以及UIH技术名)
+                </button>
+                
+                <div id="step1Result" class="result-area" style="display: none;">
+                    <strong>✅ Step 1 处理完成！</strong>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tab 2: 拒答设定 -->
+        <div id="tab2" class="tab-content">
+            <div class="card">
+                <h2 class="step-title">Step 2: 更新待定信息</h2>
+                <p class="step-desc">Step2.1 #根据友商技术在定义上的归属</p>
+                
+                <div class="table-container">
+                    <div class="table-half">
+                        <h3>👥 友商技术信息表</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>idx</th>
+                                    <th>competitor_name</th>
+                                    <th>competitor_product</th>
+                                    <th>uih_product</th>
+                                    <th>belong_to_uih</th>
+                                    <th>candidate_product</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><input type="text" value="0"></td>
+                                    <td><input type="text" value="西门子"></td>
+                                    <td><input type="text" value="DTI"></td>
+                                    <td><input type="text" value="DTI"></td>
+                                    <td><input type="text" value="false"></td>
+                                    <td><input type="text" value="GE, 飞利浦"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    
+                    <div class="table-half">
+                        <h3>🏢 UIH技术信息表</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>idx</th>
+                                    <th>belong_to_which</th>
+                                    <th>corresponding_product</th>
+                                    <th>uih_product</th>
+                                    <th>candidate_product</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><input type="text" value="0"></td>
+                                    <td><input type="text" value="DTI"></td>
+                                    <td><input type="text" value="DTI"></td>
+                                    <td><input type="text" value='["UIH", "DTI"]'></td>
+                                    <td><input type="text" value='["GE"]'></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tab 3: 原文库结论查库 -->
+        <div id="tab3" class="tab-content">
+            <div class="card">
+                <h2 class="step-title">Step 3: 获取最终拒答策略</h2>
+                <p class="step-desc">基于前两步的选择，生成最终的拒答策略结果</p>
+                
+                <button class="success" onclick="processStep3()">
+                    🎯 开始处理 (Step3获取最终拒答策略)
+                </button>
+                
+                <div id="step3Result" class="result-area" style="display: none;">
+                    <h3>📋 拒答结果</h3>
+                    <table style="margin-top: 15px;">
+                        <thead>
+                            <tr>
+                                <th>refuse_index</th>
+                                <th>candidate_text</th>
+                                <th>is_refuse</th>
+                                <th>refuse_reason</th>
+                                <th>refuse_tech</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>3</td>
+                                <td>西门子的DTI怎么样</td>
+                                <td>true</td>
+                                <td>false</td>
+                                <td>您好，您的提问涉及西门子的DTI技术，很抱歉无法为您提供咨询服务。作为上海联影医疗科技股份有限公司的人工智能助手，我的职责...</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function showTab(tabId) {
+            // 隐藏所有tab内容
+            document.querySelectorAll('.tab-content').forEach(content => {
+                content.classList.remove('active');
+            });
+            document.querySelectorAll('.tab').forEach(tab => {
+                tab.classList.remove('active');
+            });
+            
+            // 显示选中的tab
+            document.getElementById(tabId).classList.add('active');
+            event.target.classList.add('active');
+        }
+        
+        function processStep1() {
+            const text = document.getElementById('inputText').value;
+            if (text.trim()) {
+                document.getElementById('step1Result').style.display = 'block';
+                // 这里可以发送到后端处理
+                fetch('/process_step1', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({text: text})
+                });
+            } else {
+                alert('请先输入文本内容');
+            }
+        }
+        
+        function processStep3() {
+            document.getElementById('step3Result').style.display = 'block';
+            // 这里可以发送到后端处理
+            fetch('/process_step3', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({})
+            });
+        }
+    </script>
+</body>
+</html>
+"""
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write(HTML_TEMPLATE.encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+    
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length'])
+        post_data = self.rfile.read(content_length)
+        
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        
+        if self.path == '/process_step1':
+            # 处理Step 1逻辑
+            result = {"status": "success", "message": "Step 1 处理完成"}
+        elif self.path == '/process_step3':
+            # 处理Step 3逻辑
+            result = {"status": "success", "message": "Step 3 处理完成"}
+        else:
+            result = {"status": "error", "message": "未知请求"}
+        
+        self.wfile.write(json.dumps(result).encode('utf-8'))
+
+def start_server():
+    server = HTTPServer(('localhost', 8080), RequestHandler)
+    print("🚀 服务器启动成功！")
+    print("📱 请在浏览器中访问: http://localhost:8080")
+    server.serve_forever()
+
+if __name__ == '__main__':
+    # 在新线程中启动服务器，这样可以同时打开浏览器
+    server_thread = threading.Thread(target=start_server)
+    server_thread.daemon = True
+    server_thread.start()
+    
+    # 自动打开浏览器
+    try:
+        webbrowser.open('http://localhost:8080')
+    except:
+        pass
+    
+    # 保持主线程运行
+    server_thread.join()

--- a/streamlit_example.py
+++ b/streamlit_example.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+使用Streamlit实现同义词替换界面
+优点：语法简单，生态成熟，部署容易
+"""
+
+import streamlit as st
+import pandas as pd
+
+# 页面配置
+st.set_page_config(
+    page_title="同义词替换",
+    page_icon="🔄",
+    layout="wide"
+)
+
+# 主标题
+st.title("🔄 同义词替换")
+
+# 添加导航标签
+tab1, tab2, tab3 = st.tabs(["📝 文本处理", "🔧 拒答设定", "📚 原文库结论查库"])
+
+with tab1:
+    st.header("Step 1: 输入文本")
+    st.caption("请在下方文本框中输入需要测试的文本内容")
+    
+    # 文本输入区域
+    input_text = st.text_area(
+        "输入文本",
+        height=150,
+        placeholder="西门子的DTI怎么样"
+    )
+    
+    # 处理按钮
+    if st.button("🚀 开始处理 (Step1获取初步距离答案/友商以及UIH技术名)", type="primary"):
+        if input_text:
+            with st.spinner("正在处理..."):
+                # 这里添加你的处理逻辑
+                st.success("✅ Step 1 处理完成！")
+                st.session_state['step1_completed'] = True
+        else:
+            st.error("❌ 请先输入文本内容")
+
+with tab2:
+    st.header("Step 2: 更新待定信息")
+    st.caption("Step2.1 #根据友商技术在定义上的归属")
+    
+    # 创建两列布局
+    col1, col2 = st.columns(2)
+    
+    with col1:
+        st.subheader("👥 友商技术信息表")
+        
+        # 初始化数据
+        if 'competitor_df' not in st.session_state:
+            st.session_state.competitor_df = pd.DataFrame({
+                'idx': [0],
+                'competitor_name': ['西门子'],
+                'competitor_product': ['DTI'],
+                'uih_product': ['DTI'],
+                'belong_to_uih': [False],
+                'candidate_product': ['GE, 飞利浦']
+            })
+        
+        # 可编辑表格
+        edited_competitor_df = st.data_editor(
+            st.session_state.competitor_df,
+            num_rows="dynamic",
+            use_container_width=True,
+            key="competitor_table"
+        )
+        st.session_state.competitor_df = edited_competitor_df
+    
+    with col2:
+        st.subheader("🏢 UIH技术信息表")
+        
+        # 初始化数据
+        if 'uih_df' not in st.session_state:
+            st.session_state.uih_df = pd.DataFrame({
+                'idx': [0],
+                'belong_to_which': ['DTI'],
+                'corresponding_product': ['DTI'],
+                'uih_product': [['UIH', 'DTI']],
+                'candidate_product': [['GE']]
+            })
+        
+        # 可编辑表格
+        edited_uih_df = st.data_editor(
+            st.session_state.uih_df,
+            num_rows="dynamic",
+            use_container_width=True,
+            key="uih_table"
+        )
+        st.session_state.uih_df = edited_uih_df
+
+with tab3:
+    st.header("Step 3: 获取最终拒答策略")
+    st.caption("基于前两步的选择，生成最终的拒答策略结果")
+    
+    # 显示处理进度
+    if 'step1_completed' in st.session_state:
+        st.success("✅ Step 1 已完成")
+    else:
+        st.warning("⏳ 请先完成 Step 1")
+    
+    # 最终处理按钮
+    if st.button("🎯 开始处理 (Step3获取最终拒答策略)", type="primary"):
+        with st.spinner("正在生成拒答策略..."):
+            # 这里添加最终处理逻辑
+            st.success("✅ 拒答策略生成完成！")
+            
+            # 显示结果
+            st.subheader("📋 拒答结果")
+            result_data = {
+                'refuse_index': [3],
+                'candidate_text': ['西门子的DTI怎么样'],
+                'is_refuse': [True],
+                'refuse_reason': [False],
+                'refuse_tech': ['您好，您的提问涉及西门子的DTI技术，很抱歉无法为您提供咨询服务。作为上海联影医疗科技股份有限公司的人工智能助手，我的职责...']
+            }
+            
+            result_df = pd.DataFrame(result_data)
+            st.dataframe(result_df, use_container_width=True)
+
+# 侧边栏信息
+with st.sidebar:
+    st.header("ℹ️ 使用说明")
+    st.markdown("""
+    1. **文本处理**: 输入需要测试的文本
+    2. **拒答设定**: 配置友商和UIH技术信息
+    3. **查库结论**: 获取最终的拒答策略
+    """)
+    
+    st.header("📊 处理状态")
+    if 'step1_completed' in st.session_state:
+        st.success("Step 1 ✅")
+    else:
+        st.info("Step 1 ⏳")


### PR DESCRIPTION
## Change Description

Implemented two alternative user interfaces for the "Synonym Replacement" tool using Streamlit and Nicegui. This addresses the user's request for simpler, Python-native UI frameworks that require minimal frontend knowledge, moving away from Gradio.

- **`streamlit_example.py`**: Provides a Streamlit implementation, recommended for its simplicity, mature ecosystem, and ease of deployment.
- **`nicegui_example.py`**: Offers a Nicegui implementation, suitable for users prioritizing a more modern and visually appealing UI.

Both implementations feature a three-step workflow: text input, editable tables for competitor and UIH technology information, and generation of a final refusal strategy.

## Issue reference

This PR fixes issue #XX

## Checklist

- [ ] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required

---
<a href="https://cursor.com/background-agent?bcId=bc-7d86fd2d-613b-4035-a23d-83f6073e0dc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d86fd2d-613b-4035-a23d-83f6073e0dc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

